### PR TITLE
Add java options to filter java only

### DIFF
--- a/python/examples/README.md
+++ b/python/examples/README.md
@@ -147,7 +147,8 @@ class SearchfoxClient:
 
     def search(self, query=None, path=None, case=False, regexp=False,
                limit=50, context=None, symbol=None, id=None,
-               cpp=False, c_lang=False, webidl=False, js=False)
+               cpp=False, c_lang=False, webidl=False, js=False,
+               java=False)
 
     def get_file(self, path: str) -> str
 

--- a/python/searchfox/__init__.py
+++ b/python/searchfox/__init__.py
@@ -32,6 +32,7 @@ def search(
     c_lang=False,
     webidl=False,
     js=False,
+    java=False,
     log_requests=False,
 ):
     """
@@ -51,6 +52,7 @@ def search(
         c_lang: Filter to C files only
         webidl: Filter to WebIDL files only
         js: Filter to JavaScript files only
+        java: Filter to Java files only
         log_requests: Enable request logging
 
     Returns:
@@ -70,6 +72,7 @@ def search(
         c_lang=c_lang,
         webidl=webidl,
         js=js,
+        java=java,
     )
 
 

--- a/searchfox-cli/src/main.rs
+++ b/searchfox-cli/src/main.rs
@@ -141,6 +141,13 @@ struct Args {
     js: bool,
 
     #[arg(
+        long = "java",
+        help = "Filter results to Java files only",
+        long_help = "Filter results to Java files only (.java)"
+    )]
+    java: bool,
+
+    #[arg(
         long = "calls-from",
         help = "Find functions called by the specified symbol",
         long_help = "Search for functions called by the specified symbol using call graph analysis.\nExample: --calls-from 'mozilla::dom::AudioContext::CreateGain'"
@@ -327,6 +334,7 @@ async fn main() -> Result<()> {
         c_lang: args.c_lang,
         webidl: args.webidl,
         js: args.js,
+        java: args.java,
         category_filter,
     };
 

--- a/searchfox-lib/src/search.rs
+++ b/searchfox-lib/src/search.rs
@@ -64,6 +64,7 @@ pub struct SearchOptions {
     pub c_lang: bool,
     pub webidl: bool,
     pub js: bool,
+    pub java: bool,
     pub category_filter: CategoryFilter,
 }
 
@@ -82,6 +83,7 @@ impl Default for SearchOptions {
             c_lang: false,
             webidl: false,
             js: false,
+            java: false,
             category_filter: CategoryFilter::All,
         }
     }
@@ -89,7 +91,7 @@ impl Default for SearchOptions {
 
 impl SearchOptions {
     pub fn matches_language_filter(&self, path: &str) -> bool {
-        if !self.cpp && !self.c_lang && !self.webidl && !self.js {
+        if !self.cpp && !self.c_lang && !self.webidl && !self.js && !self.java {
             return true;
         }
 
@@ -121,6 +123,10 @@ impl SearchOptions {
                 || path_lower.ends_with(".jsx")
                 || path_lower.ends_with(".tsx"))
         {
+            return true;
+        }
+
+        if self.java && path_lower.ends_with(".java") {
             return true;
         }
 

--- a/searchfox-py/src/lib.rs
+++ b/searchfox-py/src/lib.rs
@@ -48,6 +48,7 @@ impl SearchfoxClient {
         c_lang: Option<bool>,
         webidl: Option<bool>,
         js: Option<bool>,
+        java: Option<bool>,
     ) -> PyResult<Vec<(String, usize, String)>> {
         let options = SearchOptions {
             query,
@@ -62,6 +63,7 @@ impl SearchfoxClient {
             c_lang: c_lang.unwrap_or(false),
             webidl: webidl.unwrap_or(false),
             js: js.unwrap_or(false),
+            java: java.unwrap_or(false),
             category_filter: searchfox_lib::CategoryFilter::All,
         };
 


### PR DESCRIPTION
When using Claude Code or Gemini CLI on Firefox repository, they try using `--java` argument to search java files on GeckoView's code. This fix adds this argument for Java source code.