### PR TITLE
Support Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,24 @@ jobs:
     - name: Run clippy
       run: cargo clippy -- -D warnings
 
+  python-bindings:
+    name: Python Bindings
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - run: python -m venv .venv
+      - uses: PyO3/maturin-action@v1
+        with:
+          command: develop
+        env:
+          VIRTUAL_ENV: .venv
+
   build:
     name: Build
     runs-on: ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,15 +1099,15 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53bdbb96d49157e65d45cc287af5f32ffadd5f4761438b527b055fb0d4bb8233"
+checksum = "f402062616ab18202ae8319da13fa4279883a2b8a9d9f83f20dbade813ce1884"
 dependencies = [
  "cfg-if",
  "indoc",
  "libc",
  "memoffset",
- "parking_lot",
+ "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
@@ -1117,9 +1117,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deaa5745de3f5231ce10517a1f5dd97d53e5a2fd77aa6b5842292085831d48d7"
+checksum = "b14b5775b5ff446dd1056212d778012cbe8a0fbffd368029fd9e25b514479c38"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -1127,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b42531d03e08d4ef1f6e85a2ed422eb678b8cd62b762e53891c05faf0d4afa"
+checksum = "9ab5bcf04a2cdcbb50c7d6105de943f543f9ed92af55818fd17b660390fc8636"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1137,9 +1137,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7305c720fa01b8055ec95e484a6eca7a83c841267f0dd5280f0c8b8551d2c158"
+checksum = "0fd24d897903a9e6d80b968368a34e1525aeb719d568dba8b3d4bfa5dc67d453"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -1149,11 +1149,11 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.20.3"
+version = "0.22.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7e9b68bb9c3149c5b0cade5d07f953d6d125eb4337723c4ccdb665f1f96185"
+checksum = "36c011a03ba1e50152b4b394b479826cad97e7a21eb52df179cd91ac411cbfbe"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ scraper = "0.23"
 env_logger = "0.11"
 log = "0.4"
 clap = { version = "4", features = ["derive"] }
-pyo3 = "0.20"
+pyo3 = "0.22"
 tabled = "0.17"
 terminal_size = "0.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,9 +18,11 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 [tool.maturin]
 python-source = "python"
 module-name = "searchfox"
 bindings = "pyo3"
+manifest-path = "searchfox-py/Cargo.toml"

--- a/searchfox-py/src/lib.rs
+++ b/searchfox-py/src/lib.rs
@@ -33,6 +33,7 @@ impl SearchfoxClient {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[pyo3(signature = (query=None, path=None, case=None, regexp=None, limit=None, context=None, symbol=None, id=None, cpp=None, c_lang=None, webidl=None, js=None, java=None))]
     fn search(
         &self,
         py: Python<'_>,
@@ -98,6 +99,7 @@ impl SearchfoxClient {
         }
     }
 
+    #[pyo3(signature = (symbol, path_filter=None))]
     fn get_definition(
         &self,
         py: Python<'_>,
@@ -124,6 +126,7 @@ impl SearchfoxClient {
         }
     }
 
+    #[pyo3(signature = (calls_from=None, calls_to=None, calls_between=None, depth=None))]
     fn search_call_graph(
         &self,
         py: Python<'_>,
@@ -226,7 +229,7 @@ impl SearchfoxClient {
 }
 
 #[pymodule]
-fn searchfox(_py: Python, m: &PyModule) -> PyResult<()> {
+fn searchfox(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<SearchfoxClient>()?;
     Ok(())
 }


### PR DESCRIPTION
When trying to build `searchfox-py`, I could not build it.  This was two issues.
- `pyproject.toml` has no `manifest-path`
- `PyO3` is old.  At least, it requires 0.22.

So this fix resolves both.  Also, this PR adds a CI for Python binding.